### PR TITLE
Don't error out the build when wpftmp folders can't be deleted

### DIFF
--- a/Directory.build.targets
+++ b/Directory.build.targets
@@ -4,6 +4,6 @@
     <ItemGroup>
       <WpfTempDirectories Include="$([System.IO.Directory]::GetDirectories('$(RepositoryRootDirectory)bin\$(Configuration)','$(MSBuildProjectName)_*_wpftmp'))" />
     </ItemGroup>
-    <RemoveDir Directories="@(WpfTempDirectories)" />
+    <RemoveDir Directories="@(WpfTempDirectories)" ContinueOnError="true" />
   </Target>
 </Project>


### PR DESCRIPTION
When the wpftmp folders are already deleted don't stop the build